### PR TITLE
Fixed tradePrase timestamp mapping

### DIFF
--- a/js/coindcx.js
+++ b/js/coindcx.js
@@ -262,7 +262,7 @@ module.exports = class coindcx extends Exchange {
     }
 
     parseTrade (trade, market = undefined) {
-        const timestamp = this.safeInteger2 (trade, 't', 'timestamp');
+        const timestamp = this.safeInteger2 (trade, 'T', 'timestamp');
         let symbol = undefined;
         if (market === undefined) {
             const marketId = this.safeString2 (trade, 's', 'symbol');


### PR DESCRIPTION
Problem: tradeParse tries to get timestamp from 't'
field in object that it receives from coindcx exchange,
 but the real timestamp is held in
'T' field.

Solution: Changed lookup of timestmap to 'T'.